### PR TITLE
fix: allow any engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,6 @@
     "index.js",
     "index.mjs"
   ],
-  "engines": {
-    "node": ">=v14",
-    "npm": ">=7",
-    "yarn": "^1"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/favware/skip-dependency.git"


### PR DESCRIPTION
I ran into a problem today where I was trying to use this in my yarn resolutions to skip a dependency but since our team is still using node 12 for legacy reasons, we were unable to install it. Since there is no executable code in this package, there is no need to limit it to only node versions `>=v14`. This PR removes the entire "engines" block of the package.json. 